### PR TITLE
hotfix correcting admin/advising section display

### DIFF
--- a/faculty-staff-includes/faculty-staff-functions.php
+++ b/faculty-staff-includes/faculty-staff-functions.php
@@ -308,11 +308,11 @@ if( !class_exists( __CLASS__ ) ) {
             $sql = "";
 
             // 1 is for Administration
-            if( $sub_dept === 1 ) 
+            if( $sub_dept === -1 ) 
                 $sql = self::$query_lib->get_query_str( FSQEnum::DEPT_ADMIN );
 
             // 2 is for Advising
-            else if( $sub_dept === 2 )
+            else if( $sub_dept === -2 )
                 $sql = self::$query_lib->get_query_str( FSQEnum::DEPT_STAFF );
 
             // This catches any of the department-specific subdepartments


### PR DESCRIPTION
Corrected the code mismatch that's causing Admin and Advising sections to not appear (missed a negative sign on two integers :\)